### PR TITLE
Update resources; streamline code

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,7 +35,7 @@ The `threads` keyword is translated to `--cpus-per-task`
 ```console
 $ cat <<'__EOF__' > Snakefile
 rule all:
-    input: "tests/norm", "tests/quick", "tests/gpu", "tests/gpu2"
+    input: "tests/norm", "tests/force_norm", "tests/quick", "tests/gpu", "tests/gpu2", "tests/tasks", "tests/ntasks"
 
 rule clean:
     shell: "rm -f tests/* logs/*"
@@ -52,17 +52,35 @@ rule quick:
     resources: runtime=10, mem_mb=1024, disk_mb=10240
     shell: "touch {output}"
 
+rule force_norm:
+    output: "tests/force_norm"
+    threads: 10
+    resources: runtime=10, mem_mb=1024, disk_mb=10240, slurm_partition="norm"
+    shell: "touch {output}"
+
 rule gpu:
     output: "tests/gpu"
     threads: 10
     resources: runtime=10, mem_mb=1024, disk_mb=10240, gpu=1, gpu_model="k80"
     shell: "touch {output}"
-    
+
 rule gpu2:
     output: "tests/gpu2"
     threads: 10
     resources: runtime=10, mem_mb=1024, disk_mb=10240, gpu=1, gpu_model="[gpuk80|gpup100]"
     shell: "set -x ; touch {output}"
+
+rule tasks:
+    output: "tests/tasks"
+    resources: tasks=2
+    shell: "touch {output}"
+
+rule ntasks:
+    output: "tests/ntasks"
+    resources: ntasks=2
+    shell: "touch {output}"
+
+
 __EOF__
 
 $ module load snakemake

--- a/bw_submit.py
+++ b/bw_submit.py
@@ -129,6 +129,10 @@ def make_sbatch_cmd(props):
         f"--partition={partition}",
     ]
 
+
+    if "slurm_extra" in resources:
+        sbatch_cmd.append(f'{resources["slurm_extra"]}')
+
     return sbatch_cmd, rule
 
 

--- a/bw_submit.py
+++ b/bw_submit.py
@@ -68,12 +68,9 @@ def make_sbatch_cmd(props):
         try:
             val = int(resources[key])
         except ValueError:
-            print(
-                f'{rule}: Could not parse {key}={resources[key]}', file=sys.stderr
-            )
+            print(f"{rule}: Could not parse {key}={resources[key]}", file=sys.stderr)
             sys.exit(1)
         return val
-
 
     # Snakemake recommended resource name is 'tasks' rather than 'ntasks', but
     # retain backwards compatibility
@@ -105,7 +102,7 @@ def make_sbatch_cmd(props):
     if "disk_mb" in resources:
         disk_mb = as_int("disk_mb")
         disk_gb = ceil(disk_mb * 1024.0)
-        gres.append(f'lscratch:{disk_gb}')
+        gres.append(f"lscratch:{disk_gb}")
 
     if "gpu" in resources:
         if "gpu_model" in resources:
@@ -113,7 +110,7 @@ def make_sbatch_cmd(props):
             # allow the definition of a constraint instead of a single gpu model.
             if "|" in model:
                 gres.append(f'gpu:{resources["gpu"]}')
-                sbatch_cmd.append(f'--constraint={model}')
+                sbatch_cmd.append(f"--constraint={model}")
             else:
                 gres.append(f'gpu:{resources["gpu_model"]}:{resources["gpu"]}')
         else:

--- a/bw_submit.py
+++ b/bw_submit.py
@@ -3,10 +3,11 @@
 """
 Snakemake SLURM submit script convenience wrapper for biowulf
 
-Everything is obtained from task resources & threads without
-any configuration files. The biowulf partition is inferred
-from resource requirements. Resource names are the conventional
-names used by other executors.
+Everything is obtained from task resources & threads without any configuration
+files. The biowulf partition is inferred from resource requirements if not
+manually specified. Resource names are the conventional names used by other
+executors, but aliases to slurm-specific resources are also included
+(https://snakemake.readthedocs.io/en/stable/executing/cluster.html#advanced-resource-specifications)
 
 Required resources: mem_mb
 Optional resources: disk_mb, gpu, gpu_model, runtime, ntasks, nodes
@@ -16,7 +17,6 @@ Optional resources: disk_mb, gpu, gpu_model, runtime, ntasks, nodes
 import argparse
 import sys
 import os
-#from pathlib import Path
 from math import ceil
 from subprocess import run
 from snakemake.utils import read_job_properties

--- a/bw_submit.py
+++ b/bw_submit.py
@@ -127,7 +127,10 @@ def make_sbatch_cmd(props):
     if len(gres) > 0:
         sbatch_cmd.append(f'--gres={",".join(gres)}')
 
-    partition = assign_partition(threads, mem_mb, time_min, gres, ntasks, nodes)
+    if "slurm_partition" in resources:
+        partition = resources["slurm_partition"]
+    else:
+        partition = assign_partition(threads, mem_mb, time_min, gres, ntasks, nodes)
 
     sbatch_cmd += [
         f"--output=logs/{rule}-%j.out",

--- a/bw_submit.py
+++ b/bw_submit.py
@@ -101,7 +101,7 @@ def make_sbatch_cmd(props):
 
     if "disk_mb" in resources:
         disk_mb = as_int("disk_mb")
-        disk_gb = ceil(disk_mb * 1024.0)
+        disk_gb = ceil(disk_mb / 1024.0)
         gres.append(f"lscratch:{disk_gb}")
 
     if "gpu" in resources:

--- a/bw_submit.py
+++ b/bw_submit.py
@@ -61,6 +61,11 @@ def make_sbatch_cmd(props):
 
     sbatch_cmd = ["sbatch", f"--cpus-per-task={threads}"]
 
+    # Snakemake resource name is 'tasks' rather than 'ntasks', but retain
+    # backwards compatibility
+    if "tasks" in resources:
+        resources["ntasks"] = resources["tasks"]
+
     if "ntasks" in resources:
         try:
             ntasks = int(resources["ntasks"])


### PR DESCRIPTION
- support `tasks`, `slurm_partition`, and `slurm_extra` resources from [this section of the snakemake docs](https://snakemake.readthedocs.io/en/stable/executing/cluster.html#advanced-resource-specifications)
- streamline a bit by factoring out converting resource values to `int` (and exiting 1 if it fails) into new `as_int()`
- if `runtime` resource was provided, but cannot be converted to int, then fail with an error
- if `mem_mb` resource cannot be converted to int, then fail with an error
- if `slurm_partition` resource was provided, use it to override the partition auto-detection
- update readme with additional tests