### PR TITLE
rm verbose arg

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,7 +9,6 @@ latency-wait: 240
 jobs: 50
 keep-going: True
 rerun-incomplete: True
-verbose: True
 # note that the space before the -- is necessary - otherwise cluster
 # execution failes as --cleanenv gets interpreted as a new option since
 # snakemake passes this on as --singularity-args "--cleanenv" - i.e. without


### PR DESCRIPTION
In previous versions of Snakemake, the `--verbose` option printed out generally useful info (IIRC), but In recent-ish versions it prints out debug info from the solver which clutters up the log.