### PR TITLE
Mem and disk updates

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,6 +6,10 @@ Snakemake profile for biowulf
 >
 > ## This branch uses the generic cluster executor in snakemake >=8
 > 
+> You may need to install
+> [snakemake-executor-plugin-cluster-generic](https://github.com/snakemake/snakemake-executor-plugin-cluster-generic)
+> via pip or conda into the same environment as Snakemake.
+> 
 > The main branch is for snakemake<8. At some point the snakemake8
 > branch will become the default.
 

--- a/Readme.md
+++ b/Readme.md
@@ -62,7 +62,7 @@ rule norm:
 rule quick:
     output: "tests/quick"
     threads: 10
-    resources: runtime=10, mem_mb=1024, disk_mb=10240
+    resources: runtime="1h", mem_mb=1024, disk_mb=10240
     shell: "touch {output}"
 
 rule force_norm:
@@ -80,17 +80,17 @@ rule gpu:
 rule gpu2:
     output: "tests/gpu2"
     threads: 10
-    resources: runtime=10, mem_mb=1024, disk_mb=10240, gpu=1, gpu_model="[gpuk80|gpup100]"
+    resources: runtime=10, mem_mb=1024, disk="10g", gpu=1, gpu_model="[gpuk80|gpup100]"
     shell: "set -x ; touch {output}"
 
 rule tasks:
     output: "tests/tasks"
-    resources: tasks=2
+    resources: tasks=2, mem="1g"
     shell: "touch {output}"
 
 rule ntasks:
     output: "tests/ntasks"
-    resources: ntasks=2
+    resources: ntasks=2, mem_mb=1024
     shell: "touch {output}"
 
 

--- a/Readme.md
+++ b/Readme.md
@@ -96,7 +96,7 @@ rule ntasks:
 
 __EOF__
 
-$ module load snakemake
+$ module load snakemake/8
 $ git clone https://github.com/NIH-HPC/snakemake_profile.git
 $ snakemake --profile snakemake_profile
 ```


### PR DESCRIPTION
This PR updates comments, readme, error message, and tests for [`mem` and `disk` resources](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#snakefiles-standard-resources). There are no changes to the code itself.

- Added comments to `bw_submit.py` in case future readers are confused like I was initially (turns out Snakemake auto-interprets `mem` strings to `mem_mb` so there's no need to handle `mem` separately in the submit script; same for `disk` and `runtime`)
- Added note about needing the executor installed, in case a user is managing packages themselves
- Updated to `module load snakemake/8` in readme. That should probably be updated once Biowulf sets it to default, but for now is needed to run correctly.
- Several rules from the readme test were missing memory resources, so I updated one with `mem` and one with `mem_mb`
- Also changed one `disk_mb` to `disk`, and changed a `runtime` to `1h` to test both string and int behavior
- Confirmed that the updated Snakefile in the readme works on Biowulf