### PR TITLE
use max-jobs-per-timespan

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,7 @@ cluster-generic-submit-cmd: bw_submit.py
 cluster-generic-status-cmd: bw_status.py
 cluster-generic-cancel-cmd: scancel
 cluster-generic-cancel-nargs: 50
-max-jobs-per-second: 1
+max-jobs-per-timespan: "60/1m"
 max-status-checks-per-second: 1
 local-cores: 4
 latency-wait: 240


### PR DESCRIPTION
With `--max-jobs-per-second=1`, it seems that multiple jobs are not submitted -- this seems to be https://github.com/snakemake/snakemake/issues/3019.

This provides a workaround, using the new arg `--max-jobs-per-timespan` which replaces the deprecated `--max-jobs-per-second`.

Turns out that a value of `"1/1s"` has the same issue, but `"60/1m"` seems to avoid that bug.